### PR TITLE
Fix module menu enabling quoting

### DIFF
--- a/core/modules/modScrapBoost.class.php
+++ b/core/modules/modScrapBoost.class.php
@@ -328,7 +328,7 @@ class modScrapBoost extends DolibarrModules
 			'url' => '/ecommerce/ecommerceindex.php',
 			'langs' => 'ecommerce@ecommerce', // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 1000 + $r,
-			'enabled' => 'isModEnabled('ecommerce')', // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled.
+                        'enabled' => "isModEnabled('ecommerce')", // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled.
 			'perms' => '1', // Use 'perms'=>'$user->hasRight("ecommerce", "myobject", "read")' if you want your menu with a permission rules
 			'target' => '',
 			'user' => 2, // 0=Menu for internal users, 1=external users, 2=both
@@ -347,7 +347,7 @@ class modScrapBoost extends DolibarrModules
 			'url' => '/ecommerce/ecommerceindex.php',
 			'langs' => 'ecommerce@ecommerce',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 1000 + $r,
-			'enabled' => 'isModEnabled('ecommerce')', // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled.
+                        'enabled' => "isModEnabled('ecommerce')", // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled.
 			'perms' => '$user->hasRight("ecommerce", "myobject", "read")',
 			'target' => '',
 			'user' => 2,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -362,7 +362,7 @@ class modScrapBoost extends DolibarrModules
 			'url' => '/ecommerce/myobject_card.php?action=create',
 			'langs' => 'ecommerce@ecommerce',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 1000 + $r,
-			'enabled' => 'isModEnabled('ecommerce')', // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+                        'enabled' => "isModEnabled('ecommerce')", // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
 			'perms' => '$user->hasRight("ecommerce", "myobject", "write")'
 			'target' => '',
 			'user' => 2,				                // 0=Menu for internal users, 1=external users, 2=both
@@ -377,7 +377,7 @@ class modScrapBoost extends DolibarrModules
 			'url' => '/ecommerce/myobject_list.php',
 			'langs' => 'ecommerce@ecommerce',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 1000 + $r,
-			'enabled' => 'isModEnabled('ecommerce')', // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled.
+                        'enabled' => "isModEnabled('ecommerce')", // Define condition to show or hide menu entry. Use 'isModEnabled('ecommerce')' if entry must be visible if module is enabled.
 			'perms' => '$user->hasRight("ecommerce", "myobject", "read")'
 			'target' => '',
 			'user' => 2,				                // 0=Menu for internal users, 1=external users, 2=both


### PR DESCRIPTION
## Summary
- escape quotes around ecommerce mod enable checks to avoid syntax errors

## Testing
- `php -l core/modules/modScrapBoost.class.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec198f8308330b67ff675c45b5daf