### PR TITLE
Rename Dolibarr module class

### DIFF
--- a/admin/about.php
+++ b/admin/about.php
@@ -108,8 +108,8 @@ print load_fiche_titre($langs->trans($title), $linkback, 'title_setup');
 $head = ecommerceAdminPrepareHead();
 print dol_get_fiche_head($head, 'about', $langs->trans($title), 0, 'ecommerce@ecommerce');
 
-dol_include_once('/ecommerce/core/modules/modScrapBoost.class.php');
-$tmpmodule = new modScrapBoost($db);
+dol_include_once('/ecommerce/core/modules/modEcommerce.class.php');
+$tmpmodule = new modEcommerce($db);
 print $tmpmodule->getDescLong();
 
 // Page end

--- a/core/modules/modEcommerce.class.php
+++ b/core/modules/modEcommerce.class.php
@@ -22,7 +22,7 @@
  * 	\defgroup   ecommerce     Module Ecommerce
  *  \brief      Ecommerce module descriptor.
  *
- *  \file       htdocs/ecommerce/core/modules/modScrapBoost.class.php
+ *  \file       htdocs/ecommerce/core/modules/modEcommerce.class.php
  *  \ingroup    ecommerce
  *  \brief      Description and activation file for module Ecommerce
  */
@@ -32,7 +32,7 @@ include_once DOL_DOCUMENT_ROOT.'/core/modules/DolibarrModules.class.php';
 /**
  *  Description and activation class for module Ecommerce
  */
-class modScrapBoost extends DolibarrModules
+class modEcommerce extends DolibarrModules
 {
 	/**
 	 * Constructor. Define names, constants, directories, boxes, permissions
@@ -62,7 +62,7 @@ class modScrapBoost extends DolibarrModules
 		// Gives the possibility for the module, to provide his own family info and position of this family (Overwrite $this->family and $this->module_position. Avoid this)
 		//$this->familyinfo = array('myownfamily' => array('position' => '01', 'label' => $langs->trans("MyOwnFamily")));
 		// Module label (no space allowed), used if translation string 'ModuleEcommerceName' not found (Ecommerce is name of module).
-		$this->name = preg_replace('/^mod/i', '', get_class($this));
+                $this->name = 'ecommerce';
 
 		// DESCRIPTION_FLAG
 		// Module description, used if translation string 'ModuleEcommerceDesc' not found (Ecommerce is name of module).

--- a/sql/dolibarr_allversions.sql
+++ b/sql/dolibarr_allversions.sql
@@ -1,3 +1,6 @@
 --
 -- Script run when an upgrade of Dolibarr is done. Whatever is the Dolibarr version.
+
+-- Remove legacy constant from previous module name
+DELETE FROM llx_const WHERE name = 'MAIN_MODULE_TEST';
 --


### PR DESCRIPTION
## Summary
- rename modScrapBoost to modEcommerce
- use explicit module name `ecommerce`
- update about page include
- clean obsolete constant during upgrade

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec8b71e008330a276a87dce2f7818